### PR TITLE
Update publish_docker.yml to include arm64 docker image support

### DIFF
--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -37,10 +37,17 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master' }}
             type=edge,branch=develop
             type=ref,event=tag
+      
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v2
         with:
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Add multi-arch to docker image build.

I have built and tested this workflow on my branch. Unfortunately, I could not get armv7 support to work. It seems that cypress does not support arm 32 bit. https://github.com/cypress-io/cypress/issues/4478

